### PR TITLE
Add experimentsLoadedCallback.

### DIFF
--- a/Mixpanel/Mixpanel.h
+++ b/Mixpanel/Mixpanel.h
@@ -634,6 +634,7 @@
  You do not need to call this method on the main thread.
  */
 - (void)joinExperiments;
+- (void)joinExperimentsWithExperimentsLoadedCallback:(void(^)())experimentsLoadedCallback;
 
 - (void)createAlias:(NSString *)alias forDistinctID:(NSString *)distinctID;
 

--- a/Mixpanel/Mixpanel.m
+++ b/Mixpanel/Mixpanel.m
@@ -1706,14 +1706,25 @@ static Mixpanel *sharedInstance = nil;
     });
 }
 
-- (void)joinExperiments
+- (void)joinExperimentsWithExperimentsLoadedCallback:(void(^)())experimentsLoadedCallback
 {
     [self checkForVariantsWithCompletion:^(NSSet *newVariants) {
         for (MPVariant *variant in newVariants) {
             [variant execute];
             [self markVariantRun:variant];
         }
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (experimentsLoadedCallback) {
+                experimentsLoadedCallback();
+            }
+        });
     }];
+}
+
+- (void)joinExperiments
+{
+    [self joinExperimentsWithExperimentsLoadedCallback:nil];
 }
 
 @end


### PR DESCRIPTION
Here is a lower risk proposal to getting our retention data in order. I'm adding a callback to let Paper know when experiments have definitively been loaded, at which point the $experiments super property is in place for all future events.

In Paper, when this callback is executed, we'll log a new "appFirstLaunchedAfterExperimentsStarted" event, which will fire in addition to our existing and untouched "appFirstLaunched" event. appFirstLaunched may not (and likely will not) contain $experiments property, so we can't use this for retention metrics, but appFirstLaunchedAfterExperimentsStarted is guaranteed to have $experiments property, so we'll use that instead when we want to compare experiment results. I talked with @wmorein already about this to get signoff on this approach.

PTAL @floatplane @petersibley 
